### PR TITLE
Centralize commit prompts in prompt.py and improve commit message generation

### DIFF
--- a/src/gai/ollama_client.py
+++ b/src/gai/ollama_client.py
@@ -1,6 +1,10 @@
 import requests
 from gai.provider import Provider
 from gai.logger import logger
+from gai.prompt import (
+    build_system_prompt,
+    build_human_prompt
+)
 
 DEFAULT_OLLAMA_MODEL = "llama3.2"
 DEFAULT_MAX_TOKENS = 2000  # Conservative limit for context window
@@ -21,56 +25,9 @@ class OllamaProvider(Provider):
     ) -> str:
         """Generate commit message for a single diff chunk."""
         logger.debug(f"Generating message for chunk with {len(diff_chunk)} characters")
-
-        # Unified system prompt (mirrors OpenAI provider prompt)
-        system_prompt = (
-            "You are to act as an expert author of git commit messages. "
-            "Your mission is to create clean and concise commit messages following the Conventional Commit specification. "
-            "I will provide you with the output of 'git diff --staged' and you must convert it into a proper commit message.\n\n"
-            "**COMMIT FORMAT RULES:**\n"
-            "- Use ONLY these conventional commit keywords: fix, feat, build, chore, ci, docs, style, refactor, perf, test\n"
-            "- Format: <type>[optional scope]: <description>\n"
-            "- Use present tense (e.g., 'add feature' not 'added feature')\n"
-            "- Keep subject line under 50 characters\n"
-        )
-        if not oneline:
-            system_prompt += (
-                "\n- Lines in body must not exceed 72 characters\n\n"
-                "**BODY FORMAT (for multiple changes):**\n"
-                "- Use bullet points (- ) for multiple changes\n"
-                "- Each bullet point should be concise and specific\n"
-                "- Start each bullet with a verb (add, fix, update, remove, etc.)\n"
-                "- Focus on WHAT changed, not HOW it was implemented\n\n"
-            )
-        system_prompt += (
-            "**OUTPUT REQUIREMENTS:**\n"
-            "- Your response MUST contain ONLY the raw commit message text\n"
-            "- NO introductory phrases like 'Here is the commit message:'\n"
-            "- NO markdown formatting or code blocks\n"
-            "- NO explanations or comments\n"
-            "- NO quotation marks around the message\n"
-            "- FOCUS on this specific part of the changes\n"
-        )
-        if not oneline:
-            system_prompt += (
-                "\n\n**EXAMPLES:**\n"
-                "feat: add user authentication system\n\n"
-                "- Implement JWT-based authentication for API security\n"
-                "- Add login and registration with password hashing\n"
-                "- Include middleware for protecting sensitive routes\n\n"
-                "fix: resolve database connection issues\n\n"
-                "- Fix connection pool timeout configuration\n"
-                "- Add retry logic for failed database queries\n"
-                "- Update error handling for connection failures"
-            )
-        if oneline:
-            system_prompt += (
-                "\n\n**ONE-LINE COMMIT MESSAGE REQUIREMENTS:**\n"
-                "- Your response MUST be a single line.\n"
-                "- NO body or footer.\n"
-                "- Keep the entire message concise and under 72 characters.\n"
-            )
-        user_prompt = f"Generate a commit message for this git diff:\n\n{diff_chunk}"
+        commit_type = "oneline" if oneline else "descriptive"
+        system_prompt = build_system_prompt(commit_type)
+        user_prompt = build_human_prompt(diff_chunk)
         json_payload = {
             "model": self.model,
             "messages": [

--- a/src/gai/openai_client.py
+++ b/src/gai/openai_client.py
@@ -1,6 +1,10 @@
 import os
 from openai import OpenAI
 from gai.provider import Provider
+from gai.prompt import (
+    build_system_prompt,
+    build_human_prompt
+)
 
 DEFAULT_OPENAI_MODEL = "gpt-3.5-turbo"
 
@@ -14,58 +18,9 @@ class OpenAIProvider(Provider):
         self.client = OpenAI(api_key=self.api_key)
 
     def generate_commit_message(self, diff, oneline: bool = False):
-        system_prompt = (
-            "You are to act as an expert author of git commit messages. "
-            "Your mission is to create clean and concise commit messages following the Conventional Commit specification. "
-            "\n\nI will provide you with the output of 'git diff --staged' and you must convert it into a proper commit message.\n\n"
-            "**COMMIT FORMAT RULES:**\n"
-            "- Use ONLY these conventional commit keywords: fix, feat, build, chore, ci, docs, style, refactor, perf, test\n"
-            "- Format: <type>[optional scope]: <description>\n"
-            "- Use present tense (e.g., 'add feature' not 'added feature')\n"
-            "- Keep subject line under 50 characters\n"
-        )
-
-        if not oneline:
-            system_prompt += (
-                "\n- Lines in body must not exceed 72 characters\n\n"
-                "**BODY FORMAT (for multiple changes):**\n"
-                "- Use bullet points (- ) for multiple changes\n"
-                "- Each bullet point should be concise and specific\n"
-                "- Start each bullet with a verb (add, fix, update, remove, etc.)\n"
-                "- Focus on WHAT changed, not HOW it was implemented\n\n"
-            )
-
-        system_prompt += (
-            "**OUTPUT REQUIREMENTS:**\n"
-            "- Your response MUST contain ONLY the raw commit message text\n"
-            "- NO introductory phrases like 'Here is the commit message:'\n"
-            "- NO markdown formatting or code blocks\n"
-            "- NO explanations or comments\n"
-            "- NO quotation marks around the message\n"
-        )
-
-        if not oneline:
-            system_prompt += (
-                "\n\n**EXAMPLES:**\n"
-                "feat: add user authentication system\n\n"
-                "- Implement JWT-based authentication for API security\n"
-                "- Add login and registration with password hashing\n"
-                "- Include middleware for protecting sensitive routes\n\n"
-                "fix: resolve database connection issues\n\n"
-                "- Fix connection pool timeout configuration\n"
-                "- Add retry logic for failed database queries\n"
-                "- Update error handling for connection failures"
-            )
-
-        if oneline:
-            system_prompt += (
-                "\n\n**ONE-LINE COMMIT MESSAGE REQUIREMENTS:**\n"
-                "- Your response MUST be a single line.\n"
-                "- NO body or footer.\n"
-                "- Keep the entire message concise and under 72 characters.\n"
-            )
-
-        user_prompt = f"Generate a commit message for this git diff:\n\n{diff}"
+        commit_type = "oneline" if oneline else "descriptive"
+        system_prompt = build_system_prompt(commit_type)
+        user_prompt = build_human_prompt(diff)
 
         try:
             response = self.client.chat.completions.create(

--- a/src/gai/prompt.py
+++ b/src/gai/prompt.py
@@ -1,0 +1,139 @@
+from typing import Literal
+
+
+# Core system prompt with explicit role and structured format
+SYSTEM_PROMPT_MAIN = """
+Role: You are a git commit message generator
+Task: Generate a concise commit message based on the git diff
+Format: Follow conventional commit format: type(scope): description
+
+**COMMIT FORMAT RULES:**
+- Use ONLY these types: feat, fix, docs, style, refactor, test, chore
+- Format: <type>[optional scope]: <description>
+- Use imperative mood ("add" not "added")
+- Maximum 50 characters for subject line
+- Use present tense
+- No period at end of subject
+- Capitalize first letter after colon
+
+**ANALYSIS APPROACH:**
+1. Identify changed files and their roles
+2. Determine type of change
+3. Extract main modifications
+4. Generate commit message
+
+**PRIORITY ORDER:**
+- Problem context first
+- What changed (not how)
+- Why it matters
+- Side effects if any
+""".strip()
+
+# Simplified prompt for one-line commits
+ONELINE_PROMPT = """
+**SINGLE LINE REQUIREMENTS:**
+- Response MUST be one line only
+- No body or footer
+- Maximum 72 characters total
+- Focus on most important change
+
+**EXAMPLES:**
+feat(auth): add OAuth2 integration
+fix(payment): resolve double-charging bug
+docs: update API endpoints documentation
+refactor(utils): extract validation logic
+""".strip()
+
+# Structured prompt for descriptive commits with backward reasoning
+DESCRIPTIVE_PROMPT = """
+**MULTI-LINE FORMAT:**
+Subject: type(scope): description (max 50 chars)
+[blank line]
+Body: Explain what and why (wrap at 72 chars)
+
+**DIFF ANALYSIS STEPS:**
+1. SCAN: Identify file types and locations
+2. CATEGORIZE: Determine change type
+3. SUMMARIZE: Extract key modifications
+4. GENERATE: Create commit message
+
+**BODY STRUCTURE:**
+- Problem/context statement
+- Solution approach
+- Testing verification (if relevant)
+- Breaking changes (if any)
+
+**BULLET POINTS FOR MULTIPLE CHANGES:**
+- Start with verb (add, fix, update, remove)
+- Focus on semantic meaning
+- Maximum 72 characters per line
+
+**GOOD EXAMPLE:**
+fix(payment): resolve subscription renewal issues
+
+Double-charging occurred when users renewed within
+the grace period. This fix adds idempotency checks
+to prevent duplicate transactions.
+
+- Add transaction ID validation
+- Implement retry logic with backoff
+- Update error handling for edge cases
+
+Tested with 1000 concurrent renewals.
+""".strip()
+
+# Output formatting with strict rules and anti-patterns
+OUTPUT_FORMATTING = """
+**OUTPUT REQUIREMENTS:**
+- Raw commit message text only
+- NO markdown formatting or code blocks
+- NO explanatory text or comments
+- NO quotation marks
+- Start directly with commit type
+
+**VALIDATION CHECKLIST:**
+✓ Correct type prefix
+✓ Optional scope in parentheses
+✓ Colon and space after type/scope
+✓ Imperative mood
+✓ Under character limits
+
+**ANTI-PATTERNS TO AVOID:**
+❌ "Fixed stuff" - Too vague
+❌ "Updated user.py" - Lists files not changes
+❌ "Added new feature" - No specifics
+❌ "minor changes" - Meaningless
+❌ "WIP" - Not descriptive
+""".strip()
+
+# Template for human prompt
+HUMAN_PROMPT_TEMPLATE = (
+    "Generate a commit message for this git diff:\n\n{diff_chunk}"
+)
+
+
+def build_system_prompt(commit_type: Literal["oneline", "descriptive"]) -> str:
+    """
+    Build system prompt optimized for git commit generation.
+    
+    Args:
+        commit_type: Whether to generate oneline or descriptive commits
+    
+    Returns:
+        Optimized system prompt string
+    """
+    commit_type_prompt = ONELINE_PROMPT if commit_type == "oneline" else DESCRIPTIVE_PROMPT
+    return SYSTEM_PROMPT_MAIN + "\n\n" + commit_type_prompt + "\n\n" + OUTPUT_FORMATTING
+
+
+def build_human_prompt(diff_chunk: str) -> str:
+    """
+    Build human prompt with git diff.
+    
+    Args:
+        diff_chunk: Git diff output (already chunked externally if needed)
+    
+    Returns:
+        Formatted human prompt
+    """
+    return HUMAN_PROMPT_TEMPLATE.format(diff_chunk=diff_chunk)

--- a/src/gai/prompt.py
+++ b/src/gai/prompt.py
@@ -99,11 +99,11 @@ OUTPUT_FORMATTING = """
 ✓ Under character limits
 
 **ANTI-PATTERNS TO AVOID:**
-❌ "Fixed stuff" - Too vague
-❌ "Updated user.py" - Lists files not changes
-❌ "Added new feature" - No specifics
-❌ "minor changes" - Meaningless
-❌ "WIP" - Not descriptive
+x "Fixed stuff" - Too vague
+x "Updated user.py" - Lists files not changes
+x "Added new feature" - No specifics
+x "minor changes" - Meaningless
+x "WIP" - Not descriptive
 """.strip()
 
 # Template for human prompt


### PR DESCRIPTION
### Summary

* Move hard-coded prompts out of `ollama_client.py` and `openai_client.py`.
* Add `prompt.py` with structured system and human prompts.
* Import prompts in both clients.
* Remove duplicate prompt logic in clients.
* Improve wording, colon placement, and formatting for higher quality commit messages.
* Add type safety with `Literal` for commit types.

### Why

* Single source of truth for prompts.
* Less drift between providers.
* Easier maintenance and review.
* More consistent, actionable commit messages.

### Details

* `prompt.py` exposes clear prompt builders for common scenarios.
* Clients call these builders instead of embedding strings.
* Formatting tweaks ensure stable titles, scopes, and bodies.

### Impact
* Better commit messages
* No API surface change.
* Behavior change limited to commit message content and consistency.
* Both clients produce aligned results.


### Review tips

* Check `prompt.py` for prompt text, structure, and `Literal` coverage.
* Verify imports in `ollama_client.py` and `openai_client.py`.
* Generate a few commits across types to compare outputs.


### Example output change

**Before**
```bash
gai hf.co/bartowski/Qwen2.5-7B-Instruct-1M-GGUF:IQ2_M
                                                                                
---
Suggested Commit Message:
feat: enhance prompt module with system and human prompts

- Introduce `build_system_prompt` and `build_human_prompt` functions
- Simplify and refactor code structure for generating commit messages
- Update `generate_commit_message` method to use new prompting functions
---
```

**After**
```bash
gai hf.co/bartowski/Qwen2.5-7B-Instruct-1M-GGUF:IQ2_M

---
Suggested Commit Message:
feat(prompt): refactor system and human prompts for git commit generation

- Simplify and modularize prompt building logic
- Remove redundant code from `ollama_client.py` and `openai_client.py`
- Introduce `prompt` module with structured prompts for different scenarios
- Add type safety using `Literal` to specify commit types
---
```

### Risks
* Gaps in `Literal` options leading to fallback behavior.
* Edge cases in prompt selection.
* Two prompt checking test-cases failure (expected)
```text
======================================================= short test summary info ========================================================
FAILED tests/test_ollama_client.py::test_ollama_provider_generate_commit_message - assert 'You are to act as an expert author of git commit messages.' in 'Role: You are a git commit message generator\nTask: Generat...
FAILED tests/test_openai_provider.py::test_openai_provider_generate_commit_message - assert 'You are to act as an expert author of git commit messages.' in 'Role: You are a git commit message generator\nTask: Generat...
===================================================== 2 failed, 21 passed in 0.25s =====================================================
```

### Follow-ups

* Add golden tests for prompt outputs.
* Document extension points for new commit types.
